### PR TITLE
Fixes file not found bug on Linux and ignores a warning that annoyed me.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,7 +35,7 @@
 - name: "Unarchive terraform {{ terraform_version }} zip."
   unarchive:
     copy: no
-    src:  "/tmp/terraform_{{ terraform_version }}_darwin_amd64.zip"
+    src:  "/tmp/terraform_{{ terraform_version }}_{{ ansible_system | lower }}_amd64.zip"
     dest: "{{ terraform_install_dir }}"
     creates: "{{ terraform_install_dir }}/terraform"
     mode: 0755

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,7 +30,7 @@
 #     mode: 0755
 
 - name: "Download terraform {{ terraform_version }} binary."
-  command: wget {{ terraform_download_url }} --directory-prefix=/tmp/
+  command: wget {{ terraform_download_url }} --directory-prefix=/tmp/ warn=False
 
 - name: "Unarchive terraform {{ terraform_version }} zip."
   unarchive:


### PR DESCRIPTION
Running this on Windows Sub-system for Linux (basically Ubuntu) we get a file not found because `darwin` is hardcoded in the task.  In addition, given there are issues with get_url on MacOSX then we can ignore the warning that is displayed.